### PR TITLE
fix: close modal after audio ended

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,16 +81,19 @@ export const title = Array.from('Chinese Programmer Wrong Pronunciation').map(i 
 
 export const play = (item: any, r: string) => {
   const audio = new Audio(item[`voice_${r}`])
-  audio.addEventListener('playing', () => {
+
+  audio.addEventListener('loadeddata', () => {
     word.value = item.word
     region.value = r
     phonetic.value = item[`phonetic_${r}`]
 
     modal.value = true
-    setTimeout(() => {
-      modal.value = false
-    }, 1000)
   })
+
+  audio.addEventListener('ended', () => {
+    modal.value = false
+  })
+
   audio.play()
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Close the modal after audio ended.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
fix #1 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
